### PR TITLE
feat: implement Parcours section with animated cards and hover effects

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -123,6 +123,22 @@
   @apply absolute left-1/2 top-1/2 h-4 w-4 rounded-full bg-primary -translate-x-1/2 -translate-y-1/2;
 }
 
+/* Parcours section — cockpit / logbook feel */
+.parcours-grid {
+  position: relative;
+  overflow: hidden;
+}
+
+.parcours-card {
+  @apply transition-shadow duration-300;
+}
+
+.parcours-card:hover {
+  box-shadow:
+    0 12px 40px -12px hsl(var(--primary) / 0.25),
+    0 0 0 1px hsl(var(--primary) / 0.2);
+}
+
 .hud-line {
   @apply absolute h-px bg-primary/20 w-full left-0;
 }

--- a/components/parcours-section.tsx
+++ b/components/parcours-section.tsx
@@ -1,7 +1,8 @@
 'use client';
+
 import { useRef } from 'react';
-import { motion, useScroll, useTransform } from 'framer-motion';
-import { Calendar, MapPin, ExternalLink } from 'lucide-react';
+import { motion, useInView } from 'framer-motion';
+import { MapPin, ExternalLink } from 'lucide-react';
 import { iconMap } from '@/lib/data';
 import { useTranslations } from '@/hooks/useTranslations';
 import { parseDate } from '@/lib/utils';
@@ -19,6 +20,122 @@ type Parcours = {
   icon: keyof typeof iconMap;
 };
 
+const cardVariants = {
+  hidden: {
+    opacity: 0,
+    y: 32,
+    scale: 0.96,
+    filter: 'blur(4px)',
+  },
+  visible: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    filter: 'blur(0px)',
+    transition: {
+      type: 'spring',
+      stiffness: 80,
+      damping: 18,
+      mass: 0.8,
+      delay: i * 0.12,
+    },
+  }),
+};
+
+function ParcoursItem({
+  exp,
+  index,
+}: {
+  exp: Parcours;
+  index: number;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const isInView = useInView(ref, { once: true, amount: 0.35 });
+  const IconComponent = iconMap[exp.icon];
+  const isLeft = index % 2 === 0;
+
+  return (
+    <motion.article
+      ref={ref}
+      className={`relative flex w-full mb-10 md:mb-14 gap-4 md:gap-6 ${
+        isLeft ? 'md:flex-row' : 'md:flex-row-reverse'
+      }`}
+      variants={cardVariants}
+      initial="hidden"
+      animate={isInView ? 'visible' : 'hidden'}
+      custom={index}
+    >
+      {/* Colonne gauche : badge / info courte */}
+      <div className="flex flex-col items-center md:items-start gap-3 min-w-[120px]">
+        <div className="relative">
+          <div className="h-12 w-12 rounded-full bg-primary/15 border border-primary/40 flex items-center justify-center shadow-[0_0_18px_rgba(59,130,246,0.55)]">
+            <IconComponent className="w-6 h-6 text-primary" />
+          </div>
+          <div className="absolute inset-0 rounded-full border border-primary/20 animate-[ping_1.8s_ease-out_infinite]" />
+        </div>
+
+        <div className="hidden md:block h-full w-px bg-primary/15 relative">
+          <div className="absolute top-0 -left-[3px] h-1.5 w-1.5 rounded-full bg-primary/60" />
+          <div className="absolute bottom-0 -left-[3px] h-1.5 w-1.5 rounded-full bg-primary/20" />
+        </div>
+
+        <div className="text-xs uppercase tracking-[0.16em] text-muted-foreground/80">
+          {exp.date}
+        </div>
+        <div className="text-xs text-muted-foreground flex items-center gap-1.5">
+          <MapPin className="h-3 w-3" />
+          <span>{exp.location}</span>
+        </div>
+      </div>
+
+      {/* Carte principale */}
+      <motion.div
+        className="relative flex-1"
+        variants={cardVariants}
+        custom={index}
+      >
+        <motion.div
+          className="relative bg-card/90 p-6 md:p-7 rounded-2xl shadow-lg border border-primary/10 backdrop-blur-xl parcours-card overflow-hidden group"
+          whileHover={{
+            y: -6,
+            transition: { type: 'spring', stiffness: 300, damping: 22 },
+          }}
+          transition={{ type: 'spring', stiffness: 300, damping: 22 }}
+        >
+          {/* Décor HUD subtil dans la carte */}
+          <div className="pointer-events-none absolute inset-0 opacity-[0.5]">
+            <div className="absolute inset-x-6 top-4 h-px bg-primary/10" />
+            <div className="absolute inset-y-4 left-6 w-px bg-primary/10" />
+            <div className="absolute inset-y-4 right-10 w-px bg-primary/10" />
+          </div>
+
+          <h3 className="text-lg md:text-xl font-semibold text-primary pr-8 mb-1.5 relative">
+            {exp.title}
+          </h3>
+
+          {exp.companyUrl ? (
+            <a
+              href={exp.companyUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-primary transition-colors"
+            >
+              <span className="group-hover:underline">{exp.company}</span>
+              <ExternalLink className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+            </a>
+          ) : (
+            <h4 className="text-sm text-muted-foreground">{exp.company}</h4>
+          )}
+
+          <p className="text-muted-foreground mt-3 text-sm md:text-base leading-relaxed">
+            {exp.description}
+          </p>
+        </motion.div>
+      </motion.div>
+    </motion.article>
+  );
+}
+
 export default function ParcoursSection() {
   const t = useTranslations('Parcours');
   let parcours = t.raw('items') as Parcours[];
@@ -28,15 +145,12 @@ export default function ParcoursSection() {
     companyUrl: companyLinks[exp.company],
   }));
 
-  const targetRef = useRef<HTMLDivElement>(null);
-  const { scrollYProgress } = useScroll({
-    target: targetRef,
-    offset: ['0.2 end', '0.6 start'],
-  });
-  const pathLength = useTransform(scrollYProgress, [0, 1], [0, 1]);
+  const sortedParcours = [...parcours].sort(
+    (a, b) => parseDate(b.date).getTime() - parseDate(a.date).getTime()
+  );
 
   return (
-    <section id="parcours" className="py-20 relative bg-background text-foreground">
+    <section id="parcours" className="py-20 relative bg-background text-foreground overflow-hidden">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         {/* Header */}
         <motion.div
@@ -47,61 +161,16 @@ export default function ParcoursSection() {
           className="mb-12 text-center"
         >
           <h2 className="text-3xl font-bold mb-4 cockpit-glow">{t('heading')}</h2>
-          <div className="w-20 h-1 bg-primary mx-auto mb-6"></div>
+          <div className="w-20 h-1 bg-primary mx-auto mb-6 rounded-full" />
           <p className="text-muted-foreground max-w-2xl mx-auto">{t('description')}</p>
         </motion.div>
 
-        {/* Timeline */}
-        <div ref={targetRef} className="relative max-w-3xl mx-auto">
-          <motion.div
-            style={{ scaleY: pathLength }}
-            className="absolute left-1/2 top-0 w-1 bg-primary origin-top -translate-x-1/2 h-full"
-          />
-
-          {parcours
-            .sort((a, b) => parseDate(b.date).getTime() - parseDate(a.date).getTime())
-            .map((exp, index) => {
-              const IconComponent = iconMap[exp.icon];
-              return (
-                <motion.div
-                  key={index}
-                  initial={{ opacity: 0, x: index % 2 === 0 ? -50 : 50 }}
-                  whileInView={{ opacity: 1, x: 0 }}
-                  viewport={{ once: true, margin: '-100px' }}
-                  transition={{ duration: 0.5, delay: index * 0.1 }}
-                  className="relative flex items-center justify-between w-full mb-16"
-                >
-                  <div className="relative bg-card p-6 rounded-lg shadow-lg border border-border hover:scale-[1.02] transition-transform w-[90%] mx-auto backdrop-blur-lg">
-                    <div className="absolute top-4 right-4 text-primary opacity-60">
-                      <IconComponent className="w-6 h-6" />
-                    </div>
-                    <h3 className="text-lg font-semibold text-primary">{exp.title}</h3>
-
-                    {exp.companyUrl ? (
-                      <a
-                        href={exp.companyUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="group inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-primary transition-colors"
-                      >
-                        <span className="group-hover:underline">{exp.company}</span>
-                        <ExternalLink className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-opacity" />
-                      </a>
-                    ) : (
-                      <h4 className="text-sm text-muted-foreground">{exp.company}</h4>
-                    )}
-
-                    <div className="flex items-center text-sm text-muted-foreground mt-2">
-                      <Calendar className="h-4 w-4 mr-1" />
-                      <span className="mr-3">{exp.date}</span>
-                      <MapPin className="h-4 w-4 mr-1" />
-                      <span>{exp.location}</span>
-                    </div>
-                    <p className="text-muted-foreground mt-2">{exp.description}</p>
-                  </div>
-                </motion.div>
-              );
-            })}
+        <div className="relative max-w-5xl mx-auto px-6 sm:px-8 md:px-10">
+          <div className="relative space-y-10 md:space-y-14">
+            {sortedParcours.map((exp, index) => (
+              <ParcoursItem key={index} exp={exp} index={index} />
+            ))}
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
This pull request refactors the `ParcoursSection` component to improve its visual design, interactivity, and maintainability. The main changes include introducing animated cards for each parcours entry, updating the layout for a more modern timeline feel, and enhancing the styling with new CSS classes.

**Component refactor and animation:**

* Refactored the `ParcoursSection` component to extract a new `ParcoursItem` subcomponent, which handles the rendering and animation of each parcours card using Framer Motion's `useInView` for entry animations. The cards now animate into view with a spring effect and include hover interactions for added depth. [[1]](diffhunk://#diff-3b4de0d67d9012cc4c6949b185e7a51640f25436ef7535db36a6c14cc9835e52L22-R114) [[2]](diffhunk://#diff-3b4de0d67d9012cc4c6949b185e7a51640f25436ef7535db36a6c14cc9835e52L94-R173)

**Layout and visual improvements:**

* Redesigned the timeline layout to alternate card alignment (left/right), add subtle HUD-style decorative lines, and improve the overall visual hierarchy of each entry. The left column now shows the date, location, and icon, while the right contains the main card content. [[1]](diffhunk://#diff-3b4de0d67d9012cc4c6949b185e7a51640f25436ef7535db36a6c14cc9835e52L22-R114) [[2]](diffhunk://#diff-3b4de0d67d9012cc4c6949b185e7a51640f25436ef7535db36a6c14cc9835e52L94-R173)

**Styling updates:**

* Added new CSS classes in `app/globals.css` for `.parcours-grid` and `.parcours-card`, including custom shadow and transition effects on hover to enhance the cockpit/logbook theme.

**Dependency and import changes:**

* Switched from `useScroll`/`useTransform` to `useInView` from Framer Motion for animation triggers, and removed the unused `Calendar` icon.

These changes collectively modernize the `ParcoursSection`, making it more visually engaging and maintainable.